### PR TITLE
Inappropriate exclusion setting of .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.wav
 *.pth
 *.cache
-data
+#data
 dump
 outputs
 release


### PR DESCRIPTION
Hello. I found that exclusion setting of "data" in .gitignore also excludes nnsvs_recipe_for_enunu/\*/\*/conf/train/{timelag,duration,acoustic}/data and this causes the failure in stage 2-4.  You have already set the exclusion criteria properly in nnsvs_recipe_for_enunu/ofuton_p_utagoe_db/svs-world-conv/.gitignore, so there is no need to exclude "data" in .gitignore.
