### PR TITLE
Feat: Add Vocoder Rendering Support Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+/.vscode
+/venv
+/test
+/server_start.ps1
+/pyproject.toml
+
 *.exe
 *.log
 *.wav

--- a/synthesis/enulib/common.py
+++ b/synthesis/enulib/common.py
@@ -4,13 +4,22 @@
 ENUNUで合成するときに timelag/duration/acoustic共通で使う関数とか。
 """
 from copy import copy
+import os
 from os.path import join
 
 import numpy as np
 import utaupy
 from hydra.utils import to_absolute_path
 from nnmnkwii.io import hts
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
+from nnsvs import util
+
+try:
+    from parallel_wavegan.utils import load_model
+
+    _pwg_available = True
+except ImportError:
+    _pwg_available = False
 
 
 def full2mono(path_full, path_mono):
@@ -83,3 +92,39 @@ def load_qustion(question_path, append_hat_for_LL=False) -> tuple:
     pitch_indices = np.arange(len(binary_dict), len(binary_dict) + 3)
     pitch_idx = len(binary_dict) + 1
     return (binary_dict, continuous_dict, pitch_indices, pitch_idx)
+
+
+def get_vocoder_model(config: DictConfig, device: str):
+    if not _pwg_available:
+        raise ValueError('Unable to load "parallel_wavegan" library')
+
+    typ = "vocoder"
+
+    # setup vocoder model path
+    if config.model_dir is None:
+        raise ValueError('"model_dir" config is required')
+
+    model_dir = to_absolute_path(config.model_dir)
+    config[typ].model_yaml = os.path.join(model_dir, typ, "config.yml")
+    config[typ].checkpoint = os.path.join(model_dir, typ, config[typ].checkpoint)
+
+    # setup vocoder scaler path
+    if config.stats_dir is None:
+        raise ValueError('"stats_dir" config is required')
+
+    stats_dir = to_absolute_path(config.stats_dir)
+    in_vocoder_scaler_mean = os.path.join(stats_dir, f"in_vocoder_scaler_mean.npy")
+    in_vocoder_scaler_var = os.path.join(stats_dir, f"in_vocoder_scaler_var.npy")
+    in_vocoder_scaler_scale = os.path.join(stats_dir, f"in_vocoder_scaler_scale.npy")
+
+    vocoder_config = OmegaConf.load(to_absolute_path(config[typ].model_yaml))
+    vocoder = load_model(config[typ].checkpoint, config=vocoder_config).to(device)
+    vocoder.eval()
+    vocoder.remove_weight_norm()
+    vocoder_in_scaler = util.StandardScaler(
+        np.load(in_vocoder_scaler_mean),
+        np.load(in_vocoder_scaler_var),
+        np.load(in_vocoder_scaler_scale),
+    )
+
+    return vocoder_config, vocoder, vocoder_in_scaler

--- a/synthesis/enulib/world.py
+++ b/synthesis/enulib/world.py
@@ -8,7 +8,7 @@ import joblib
 import numpy as np
 import pysptk
 import pyworld
-from enulib.common import set_checkpoint, set_normalization_stat
+from enulib.common import set_checkpoint, set_normalization_stat, get_vocoder_model
 from hydra.utils import to_absolute_path
 from nnmnkwii.io import hts
 from nnmnkwii.postfilters import merlin_post_filter
@@ -21,6 +21,7 @@ from nnsvs.logger import getLogger
 from nnsvs.multistream import get_static_stream_sizes
 from nnsvs.pitch import lowpass_filter
 from nnsvs.postfilters import variance_scaling
+from nnsvs.io.hts import segment_labels
 from omegaconf import DictConfig, OmegaConf
 from scipy.io import wavfile
 import torch
@@ -72,6 +73,155 @@ def generate_wav_file(config: DictConfig, wav, out_wav_path):
     # ファイル出力
     wav = wav.astype(np.float32)
     wavfile.write(out_wav_path, rate=config.sample_rate, data=wav)
+
+
+def get_acoustic_feature(
+    config: DictConfig,
+    path_timing,
+    path_acoustic,
+    trajectory_smoothing=True,
+    trajectory_smoothing_cutoff=50,
+    vibrato_scale=1.0,
+    vuv_threshold=0.1,
+):
+    # loggerの設定
+    global logger  # pylint: disable=global-statement
+    logger = getLogger(config.verbose)
+    logger.info(OmegaConf.to_yaml(config))
+
+    # load labels and question
+    duration_modified_labels = hts.load(path_timing).round_()
+
+    # CUDAが使えるかどうか
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+
+    # 各種設定を読み込む
+    acoustic_model_config = OmegaConf.load(to_absolute_path(config["acoustic"].model_yaml))
+
+    # hedファイルを読み取る。
+    question_path = to_absolute_path(config.question_path)
+    # hts2wav.pyだとこう↓-----------------
+    # これだと各モデルに別個のhedを適用できる。
+    # if config[typ].question_path is None:
+    #     config[typ].question_path = config.question_path
+    # --------------------------------------
+
+    # hedファイルを辞書として読み取る。
+    binary_dict, numeric_dict = hts.load_question_set(
+        question_path, append_hat_for_LL=False
+    )
+
+    # pitch indices in the input features
+    pitch_idx = len(binary_dict) + 1
+    # pitch_indices = np.arange(len(binary_dict), len(binary_dict)+3)
+
+    # pylint: disable=no-member
+    # Acousticの数値を読み取る
+    acoustic_features = np.loadtxt(
+        path_acoustic, delimiter=',', dtype=np.float64
+    )
+
+    # postfilter setting
+    try:
+        # substitute of maybe_set_checkpoints_(config)
+        set_checkpoint(config, "postfilter")
+        # substitute of maybe_set_normalization_stats_(config)
+        set_normalization_stat(config, "postfilter")
+    except Exception as e:
+        print(e)
+        print(f"There is no post_filter_type setting so merlin is used.")
+
+    try:
+        post_filter_type = config.acoustic.post_filter_type
+    except Exception as e:
+        print(e)
+        print(f"There is no post_filter_type setting so merlin is used.")
+        post_filter_type = "merlin"
+
+    if post_filter_type not in ["merlin", "nnsvs", "gv", "none"]:
+        print(f"Unknown post-filter type: {post_filter_type} so merlin is used.")
+        post_filter_type = "merlin"
+
+    if "post_filter" in config.acoustic.keys():
+        print("post_filter is deprecated. Use post_filter_type instead.")
+
+    try:
+        postfilter_out_scaler = joblib.load(config["postfilter"].out_scaler_path)
+        # Apply GV post-filtering
+        if post_filter_type in ["nnsvs", "gv"]:
+            print("Apply GV post-filtering")
+            static_stream_sizes = get_static_stream_sizes(
+                acoustic_model_config.stream_sizes,
+                acoustic_model_config.has_dynamic_features,
+                acoustic_model_config.num_windows,
+            )
+            mgc_end_dim = static_stream_sizes[0]
+            acoustic_features[:, :mgc_end_dim] = variance_scaling(
+                postfilter_out_scaler.var_.reshape(-1)[:mgc_end_dim],
+                acoustic_features[:, :mgc_end_dim],
+                offset=2,
+            )
+            # bap
+            bap_start_dim = sum(static_stream_sizes[:3])
+            bap_end_dim = sum(static_stream_sizes[:4])
+            acoustic_features[:, bap_start_dim:bap_end_dim] = variance_scaling(
+                postfilter_out_scaler.var_.reshape(-1)[bap_start_dim:bap_end_dim],
+                acoustic_features[:, bap_start_dim:bap_end_dim],
+                offset=0,
+            )
+
+            # Learned post-filter using nnsvs
+            if post_filter_type == "nnsvs":
+                postfilter_model_config = OmegaConf.load(to_absolute_path(config["postfilter"].model_yaml))
+                postfilter_model = hydra.utils.instantiate(postfilter_model_config.netG).to(device)
+
+                print("Apply mgc_postfilter")
+                in_feats = (
+                    torch.from_numpy(acoustic_features).float().unsqueeze(0)
+                )
+                in_feats = postfilter_out_scaler.transform(in_feats).float().to(device)
+                out_feats = postfilter_model.inference(in_feats, [in_feats.shape[1]])
+                acoustic_features = (
+                    postfilter_out_scaler.inverse_transform(out_feats.detach().cpu())
+                    .squeeze(0)
+                    .numpy()
+                )
+    except Exception as e:
+        print(e)
+        print("Unable to use NNSVS/GV postfilter")
+
+    # Generate static features from acoustic features
+    mgc, lf0, vuv, bap = gen_spsvs_static_features(
+        duration_modified_labels,
+        acoustic_features,
+        binary_dict,
+        numeric_dict,
+        acoustic_model_config.stream_sizes,
+        acoustic_model_config.has_dynamic_features,
+        config.acoustic.subphone_features,
+        pitch_idx,
+        acoustic_model_config.num_windows,
+        config.frame_period,
+        config.acoustic.relative_f0,
+        vibrato_scale,
+        vuv_threshold
+    )
+
+    # NOTE: spectral enhancement based on the Merlin's post-filter implementation
+    if post_filter_type == "merlin":
+        alpha = pysptk.util.mcepalpha(config.sample_rate)
+        mgc = merlin_post_filter(mgc, alpha)
+
+    # Remove high-frequency components of mgc/bap
+    # NOTE: It seems to be effective to suppress artifacts of GAN-based post-filtering
+    if trajectory_smoothing:
+        modfs = int(1 / 0.005)
+        for d in range(mgc.shape[1]):
+            mgc[:, d] = lowpass_filter(mgc[:, d], modfs, cutoff=trajectory_smoothing_cutoff)
+        for d in range(bap.shape[1]):
+            bap[:, d] = lowpass_filter(bap[:, d], modfs, cutoff=trajectory_smoothing_cutoff)
+
+    return mgc, lf0, vuv, bap
 
 
 # def acoustic2wav(config: DictConfig, path_timing, path_acoustic, path_wav):
@@ -138,174 +288,32 @@ def generate_wav_file(config: DictConfig, wav, out_wav_path):
 #     # 音量を調整して 32bit float でファイル出力
 #     generate_wav_file(config, generated_waveform, path_wav)
 
-
-def acoustic2world(config: DictConfig, path_timing, path_acoustic,
-                   path_f0, path_spcetrogram, path_aperiodicity,
-                   trajectory_smoothing=True,
-                   trajectory_smoothing_cutoff=50,
-                   vibrato_scale=1.0,
-                   vuv_threshold=0.1):
+def acoustic2world(
+    config: DictConfig,
+    path_timing,
+    path_acoustic,
+    path_f0,
+    path_spcetrogram,
+    path_aperiodicity,
+    trajectory_smoothing=True,
+    trajectory_smoothing_cutoff=50,
+    vibrato_scale=1.0,
+    vuv_threshold=0.1,
+):
     """
     Acousticの行列のCSVを読んで、WAVファイルとして出力する。
     """
-    # loggerの設定
-    global logger  # pylint: disable=global-statement
-    logger = getLogger(config.verbose)
-    logger.info(OmegaConf.to_yaml(config))
 
-    # load labels and question
-    duration_modified_labels = hts.load(path_timing).round_()
-
-    # CUDAが使えるかどうか
-    device = 'cuda' if torch.cuda.is_available() else 'cpu'
-
-    # 各種設定を読み込む
-    acoustic_model_config = OmegaConf.load(to_absolute_path(config["acoustic"].model_yaml))
-
-    # hedファイルを読み取る。
-    question_path = to_absolute_path(config.question_path)
-    # hts2wav.pyだとこう↓-----------------
-    # これだと各モデルに別個のhedを適用できる。
-    # if config[typ].question_path is None:
-    #     config[typ].question_path = config.question_path
-    # --------------------------------------
-
-    # hedファイルを辞書として読み取る。
-    binary_dict, numeric_dict = hts.load_question_set(
-        question_path, append_hat_for_LL=False
-    )
-
-    # pitch indices in the input features
-    pitch_idx = len(binary_dict) + 1
-    # pitch_indices = np.arange(len(binary_dict), len(binary_dict)+3)
-
-    # pylint: disable=no-member
-    # Acousticの数値を読み取る
-    acoustic_features = np.loadtxt(
-        path_acoustic, delimiter=',', dtype=np.float64
-    )
-
-    # postfilter setting
-    try:
-        # substitute of maybe_set_checkpoints_(config)
-        set_checkpoint(config, "postfilter")
-        # substitute of maybe_set_normalization_stats_(config)
-        set_normalization_stat(config, "postfilter")
-    except Exception as e:
-        print(e)
-        print(f"There is no post_filter_type setting so merlin is used.")
-        
-    try:
-        post_filter_type = config.acoustic.post_filter_type
-    except Exception as e:
-        print(e)
-        print(f"There is no post_filter_type setting so merlin is used.")
-        post_filter_type = "merlin"
-
-    if post_filter_type not in ["merlin", "nnsvs", "gv", "none"]:
-        print(f"Unknown post-filter type: {post_filter_type} so merlin is used.")
-        post_filter_type = "merlin"
-
-    if "post_filter" in config.acoustic.keys():
-        print("post_filter is deprecated. Use post_filter_type instead.")
-    
-    try:
-        postfilter_out_scaler = joblib.load(config["postfilter"].out_scaler_path)
-        # Apply GV post-filtering
-        if post_filter_type in ["nnsvs", "gv"]:
-            print("Apply GV post-filtering")        
-            static_stream_sizes = get_static_stream_sizes(
-                acoustic_model_config.stream_sizes,
-                acoustic_model_config.has_dynamic_features,
-                acoustic_model_config.num_windows,
-            )
-            mgc_end_dim = static_stream_sizes[0]
-            acoustic_features[:, :mgc_end_dim] = variance_scaling(
-                postfilter_out_scaler.var_.reshape(-1)[:mgc_end_dim],
-                acoustic_features[:, :mgc_end_dim],
-                offset=2,
-            )
-            # bap
-            bap_start_dim = sum(static_stream_sizes[:3])
-            bap_end_dim = sum(static_stream_sizes[:4])
-            acoustic_features[:, bap_start_dim:bap_end_dim] = variance_scaling(
-                postfilter_out_scaler.var_.reshape(-1)[bap_start_dim:bap_end_dim],
-                acoustic_features[:, bap_start_dim:bap_end_dim],
-                offset=0,
-            )
-
-            # Learned post-filter using nnsvs
-            if post_filter_type == "nnsvs":
-                postfilter_model_config = OmegaConf.load(to_absolute_path(config["postfilter"].model_yaml))
-                postfilter_model = hydra.utils.instantiate(postfilter_model_config.netG).to(device)
-
-                print("Apply mgc_postfilter")        
-                in_feats = (
-                    torch.from_numpy(acoustic_features).float().unsqueeze(0)                
-                )
-                in_feats = postfilter_out_scaler.transform(in_feats).float().to(device)
-                out_feats = postfilter_model.inference(in_feats, [in_feats.shape[1]])
-                acoustic_features = (
-                    postfilter_out_scaler.inverse_transform(out_feats.detach().cpu())
-                    .squeeze(0)
-                    .numpy()
-                )
-    except Exception as e:
-        print(e)
-        print("Unable to use NNSVS/GV postfilter")
-
-    # Generate static features from acoustic features
-    mgc, lf0, vuv, bap = gen_spsvs_static_features(
-        duration_modified_labels,
-        acoustic_features,
-        binary_dict,
-        numeric_dict,
-        acoustic_model_config.stream_sizes,
-        acoustic_model_config.has_dynamic_features,
-        config.acoustic.subphone_features,
-        pitch_idx,
-        acoustic_model_config.num_windows,
-        config.frame_period,
-        config.acoustic.relative_f0,
-        vibrato_scale,
-        vuv_threshold
-    )
-
-    # NOTE: spectral enhancement based on the Merlin's post-filter implementation
-    if post_filter_type == "merlin":
-        alpha = pysptk.util.mcepalpha(config.sample_rate)
-        mgc = merlin_post_filter(mgc, alpha)
-    
-    # Remove high-frequency components of mgc/bap
-    # NOTE: It seems to be effective to suppress artifacts of GAN-based post-filtering
-    if trajectory_smoothing:
-        modfs = int(1 / 0.005)
-        for d in range(mgc.shape[1]):
-            mgc[:, d] = lowpass_filter(
-                mgc[:, d], modfs, cutoff=trajectory_smoothing_cutoff
-            )
-        for d in range(bap.shape[1]):
-            bap[:, d] = lowpass_filter(
-                bap[:, d], modfs, cutoff=trajectory_smoothing_cutoff
-            )
+    mgc, lf0, vuv, bap = get_acoustic_feature(
+        config, path_timing, path_acoustic, trajectory_smoothing, trajectory_smoothing_cutoff, vibrato_scale, vuv_threshold)
 
     # Generate WORLD parameters
     f0, spectrogram, aperiodicity = gen_world_params(
-        mgc, lf0, vuv, bap, config.sample_rate, vuv_threshold=vuv_threshold
-    )
-            
+        mgc, lf0, vuv, bap, config.sample_rate, vuv_threshold=vuv_threshold)
+
     # csvファイルとしてf0の行列を出力
-    for path, array in (
-        (path_f0, f0),
-        (path_spcetrogram, spectrogram),
-        (path_aperiodicity, aperiodicity)
-    ):
-        np.savetxt(
-            path,
-            array,
-            fmt='%.16f',
-            delimiter=','
-        )
+    for path, array in ((path_f0, f0), (path_spcetrogram, spectrogram), (path_aperiodicity, aperiodicity)):
+        np.savetxt(path, array, fmt="%.16f", delimiter=",")
 
 
 def world2wav(config: DictConfig, path_f0, path_spectrogram, path_aperiodicity, path_wav):
@@ -324,6 +332,79 @@ def world2wav(config: DictConfig, path_f0, path_spectrogram, path_aperiodicity, 
     )
 
     wav = bandpass_filter(wav, config.sample_rate)
-    
+
     # 音量を調整して 32bit float でファイル出力
+    generate_wav_file(config, wav, path_wav)
+
+
+@torch.no_grad()
+def acoustic2vocoder_wav(
+    config: DictConfig,
+    path_timing,
+    path_acoustic,
+    path_wav,
+    trajectory_smoothing=True,
+    trajectory_smoothing_cutoff=50,
+    vibrato_scale=1.0,
+    vuv_threshold=0.1,
+    use_segment_label=False,
+):
+    # load labels and question
+    duration_modified_labels = hts.load(path_timing).round_()
+
+    # CUDAが使えるかどうか
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+
+    mgc, lf0, vuv, bap = get_acoustic_feature(
+        config, path_timing, path_acoustic, trajectory_smoothing, trajectory_smoothing_cutoff, vibrato_scale, vuv_threshold)
+
+    model_config, model, in_scaler = get_vocoder_model(config, device)
+
+    vuv = (vuv > vuv_threshold).astype(np.float32)
+    voc_inp = torch.from_numpy(in_scaler.transform(np.concatenate([mgc, lf0, vuv, bap], axis=-1))).float()
+
+    if use_segment_label:
+        segmented_labels = segment_labels(duration_modified_labels)
+        from tqdm.auto import tqdm
+
+        overlap = 100
+        overlap_wav = overlap * model_config.hop_size
+
+        wavs = []
+        end_time_store = 0
+        for idx, seg_labels in enumerate(tqdm(segmented_labels)):
+            start_time = seg_labels.start_times[0] // 50000 + end_time_store
+            end_time = seg_labels.end_times[-1] // 50000 + end_time_store
+            end_time_store = end_time
+
+            if idx > 0:
+                start_time -= overlap
+            if idx < len(segmented_labels) - 1:
+                end_time += overlap
+
+            wav = model.inference(voc_inp[start_time:end_time].to(device)).view(-1).to("cpu").numpy()
+
+            if idx > 0:
+                wav = wav[overlap_wav:]
+            if idx < len(segmented_labels) - 1:
+                wav = wav[:-overlap_wav]
+
+            wavs.append(wav)
+            print(f"infer: {start_time} ~ {end_time}")
+
+        # Concatenate segmented wavs
+        wav = np.concatenate(wavs, axis=0).reshape(-1)
+    else:
+        wav = model.inference(voc_inp.to(device)).view(-1).to("cpu").numpy()
+
+    # post-processing
+    wav = bandpass_filter(wav, model_config.sampling_rate)
+
+    if np.max(wav) > 10:
+        # data is likely already in [-32768, 32767]
+        wav = wav.astype(np.int16)
+    else:
+        wav = np.clip(wav, -1.0, 1.0)
+        wav = (wav * 32767.0).astype(np.int16)
+
     generate_wav_file(config, wav, path_wav)

--- a/synthesis/enunu.py
+++ b/synthesis/enunu.py
@@ -316,6 +316,15 @@ def main_as_plugin(path_plugin: str, path_wav: Union[str, None]) -> str:
             path_spectrogram,
             path_aperiodicity
         )
+    elif calculator == "built-in-vocoder":
+        print(
+            f"{datetime.now()} : calculating acoustic with built-in-vocoder function")
+        # timing.full から acoustic.csv を作る。
+        enulib.acoustic.timing2acoustic(
+            config,
+            path_full_timing,
+            path_acoustic
+        )
     else:
         print(
             f'{datetime.now()} : calculating acoustic with {calculator}')
@@ -368,6 +377,17 @@ def main_as_plugin(path_plugin: str, path_wav: Union[str, None]) -> str:
             path_f0,
             path_spectrogram,
             path_aperiodicity,
+            path_wav
+        )
+
+    # 組み込まれたVocoderで合成する場合
+    elif synthesizer == "vocoder":
+        print(f"{datetime.now()} : synthesizing WAV with vocoder model")
+        # timing.full から acoustic.csv を作る。
+        enulib.world.acoustic2vocoder_wav(
+            config,
+            path_full_timing,
+            path_acoustic,
             path_wav
         )
 


### PR DESCRIPTION
### This PR adds code to support rendering of the vocoder in v0.0.3 in NNSVS.

Vocoder model and scaler path
```
exp/vb_name/vocoder
 - checkpoint-000000steps.pkl
 - config.yml

dump/vb_name/norm
 - in_vocoder_scaler_mean.npy
 - in_vocoder_scaler_scale.npy
 - in_vocoder_scaler_var.npy
```

setting enucconfig.yaml option
```
vocoder:
    checkpoint: checkpoint-000000steps.pkl
    in_scaler_path: null

extensions:
    ...
    acoustic_calculator: built-in-vocoder
    ...
    wav_synthesizer: vocoder
    ...
```

Please let me know if there is anything to modify